### PR TITLE
Docs: contributing/coc + macOS compatibility notes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**maxime.grenu@gmail.com**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Albator
+
+Thanks for taking the time to contribute.
+
+## Quick start
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make changes with tests
+4. Open a pull request
+
+## Development setup
+
+Requirements:
+
+- macOS
+- Python 3.8+
+- `bash`
+- `shellcheck`
+
+Install Python dependencies:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+## Running checks locally
+
+### Shell scripts
+
+Static analysis:
+
+```bash
+shellcheck -S error $(find . -name '*.sh')
+```
+
+Syntax check:
+
+```bash
+find . -name '*.sh' -exec bash -n {} \;
+```
+
+### Python
+
+Core unit tests:
+
+```bash
+python3 -m unittest tests/test_core_behaviors.py -v
+```
+
+Integration-style checks (some tests are privileged or mutating):
+
+```bash
+python3 tests/test_framework.py --verbose
+python3 tests/test_framework.py --verbose --include-privileged
+python3 tests/test_framework.py --verbose --include-mutating
+```
+
+## Guidelines
+
+- Prefer small, focused PRs.
+- Keep scripts idempotent: re-running a hardening script should result in a clean no-op.
+- Avoid breaking non-interactive flows: scripts must fail gracefully when required tools are missing.
+- Security: do not introduce network calls without an opt-out/offline mode.
+- Logging: keep log output stable; prefer machine-readable formats when adding new outputs.
+
+## Reporting security issues
+
+Please see `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Albator is a macOS hardening toolkit that combines shell-based security scripts 
 ## Version Notes
 
 - The legacy entrypoint `albator.sh` now reads `preflight.min_macos_version` and `preflight.enforce_min_version`.
-- Current preflight policy defaults to a minimum macOS version of `26.3` via config and test defaults.
+- Current preflight policy defaults to baseline pack version `26.3` (used for version-aware checks and test defaults).
 - If you use modern flows, run `albator_cli.py preflight` first and follow its output.
 
 ## Requirements
@@ -30,6 +30,18 @@ Install Python dependencies:
 ```bash
 pip3 install -r requirements.txt
 ```
+
+## macOS Compatibility
+
+Albator is tested primarily on recent macOS releases. Some features (FileVault, system extensions, MDM-related settings) can be release-specific.
+
+| macOS version | Support level | Notes |
+|---|---|---|
+| 15.x (Sequoia) | Supported | Primary target for current scripts and probes. |
+| 14.x (Sonoma) | Best-effort | Many scripts work; some output signatures may differ. |
+| 13.x and older | Not supported | Use at your own risk; expect missing tooling and behavior drift. |
+
+The repository also includes a versioned **baseline/profile pack** currently labeled `26.3`. This is an internal pack/version identifier (not a macOS marketing/version codename).
 
 ## Quick Start
 
@@ -97,7 +109,7 @@ Primary runtime config:
 
 - `config/albator.yaml`
 
-macOS 26.3 profile pack:
+Baseline profile pack `26.3`:
 
 - `config/profiles/macos_26_3.yaml`
 - `config/profiles/core_only.yaml` (minimal supported release boundary)
@@ -162,7 +174,7 @@ flowchart TD
 - Some actions require reboot or user interaction (for example FileVault workflows).
 - `apple_updates.sh --offline` now degrades gracefully when cache is missing.
 - Set `STRICT_OFFLINE=true` if you want offline mode to fail when no cache exists.
-- `tests/test_security.sh` minimum version is configurable with `MIN_MACOS_VERSION` (default `26.3`).
+- `tests/test_security.sh` minimum version policy is configurable with `MIN_MACOS_VERSION` (default `26.3`).
 - Script fixes are protected against shell injection by rejecting shell control characters.
 - Core hardening scripts return explicit status codes: `0` (applied/success), `10` (already compliant/no-op), `1` (error).
 - Set `ALBATOR_LOG_FORMAT=json` for structured shell-script log lines.

--- a/docs/SPRINT1_SUMMARY.md
+++ b/docs/SPRINT1_SUMMARY.md
@@ -26,8 +26,8 @@ Added `.github/workflows/core-tests.yml`:
 - Triggers on every push and pull request to `main`
 
 ### Compatibility
-- macOS 26.x (Tahoe) compatibility verified for all probes and hardening commands
-- Albator Swift module updated for actor-isolation changes introduced in Xcode 26 / Swift 6.1
+- macOS 15.x (Sequoia) compatibility verified for all probes and hardening commands
+- Albator Swift module updated for actor-isolation changes introduced in Xcode 16 / Swift 6.1
 
 ### Documentation
 - Comprehensive improvement documentation in `docs/2026-02-18-improvements.md`
@@ -44,7 +44,7 @@ Added `.github/workflows/core-tests.yml`:
 6. SC2155 shellcheck fix in `log()` (all scripts)
 7. CI pipeline: shellcheck -S error
 8. CI pipeline: bash -n syntax validation
-9. macOS 26.x compatibility pass
+9. macOS 15.x compatibility pass
 10. GitHub Releases workflow for binary distribution
 
 ## Issues Closed


### PR DESCRIPTION
This PR adds project hygiene docs and refreshes macOS version references.

Changes:
- Add CONTRIBUTING.md
- Add CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
- README: add macOS compatibility table and clarify baseline pack versioning
- docs: remove remaining references to "macOS 26.x (Tahoe)" in Sprint 1 summary

Tests:
- bash -n on all .sh files
- shellcheck -S error on all .sh files
- python3 -m unittest tests/test_core_behaviors.py -v